### PR TITLE
Update for https://github.com/rust-lang/rust/pull/30043

### DIFF
--- a/quasi_codegen/src/lib.rs
+++ b/quasi_codegen/src/lib.rs
@@ -22,7 +22,7 @@ extern crate syntex_syntax as syntax;
 extern crate syntax;
 
 #[cfg(not(feature = "with-syntex"))]
-extern crate rustc;
+extern crate rustc_plugin;
 
 use syntax::ast;
 use syntax::codemap::Span;
@@ -739,7 +739,7 @@ pub fn register(reg: &mut syntex::Registry) {
 }
 
 #[cfg(not(feature = "syntex"))]
-pub fn register(reg: &mut rustc::plugin::Registry) {
+pub fn register(reg: &mut rustc_plugin::Registry) {
     reg.register_macro("quote_tokens", expand_quote_tokens);
     reg.register_macro("quote_ty", expand_quote_ty);
     reg.register_macro("quote_expr", expand_quote_expr);

--- a/quasi_macros/src/lib.rs
+++ b/quasi_macros/src/lib.rs
@@ -11,10 +11,10 @@
 #![feature(plugin_registrar, unboxed_closures, rustc_private)]
 
 extern crate quasi_codegen;
-extern crate rustc;
+extern crate rustc_plugin;
 
 #[plugin_registrar]
 #[doc(hidden)]
-pub fn plugin_registrar(reg: &mut rustc::plugin::Registry) {
+pub fn plugin_registrar(reg: &mut rustc_plugin::Registry) {
     quasi_codegen::register(reg);
 }


### PR DESCRIPTION
`rustc::plugin` is now `rustc_plugin`
