### PR TITLE
Update for rust-lang/rust#29850

### DIFF
--- a/quasi/src/lib.rs
+++ b/quasi/src/lib.rs
@@ -241,6 +241,7 @@ impl ToTokens for ast::Lit {
             id: ast::DUMMY_NODE_ID,
             node: ast::ExprLit(P(self.clone())),
             span: DUMMY_SP,
+            attrs: None,
         }).to_tokens(cx)
     }
 }


### PR DESCRIPTION
Attrs are now allowed in statement and expression contexts. This will of
course break the build, as syntex_syntax will need to be updated as
well.

I also noticed that the test suite doesn't check nightly, only stable.
Perhaps we should update to run both?
