### PR TITLE
Update for structured errors rust-lang/rust#30542

### DIFF
--- a/quasi/Cargo.toml
+++ b/quasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quasi"
-version = "0.3.11"
+version = "0.3.12"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A quasi-quoting macro system"

--- a/quasi/src/lib.rs
+++ b/quasi/src/lib.rs
@@ -329,11 +329,20 @@ impl<'a> ExtParseUtils for ExtCtxt<'a> {
     }
 }
 
+// A variant of 'try!' that panics on an Err. This is used as a crutch on the
+// way towards a non-panic!-prone parser. It should be used for fatal parsing
+// errors; eventually we plan to convert all code using panictry to just use
+// normal try.
 macro_rules! panictry {
     ($e:expr) => ({
+        use std::result::Result::{Ok, Err};
+        use syntax::errors::FatalError;
         match $e {
             Ok(e) => e,
-            Err(err) => panic!(err)
+            Err(mut e) => {
+                e.emit();
+                panic!(FatalError);
+            }
         }
     })
 }

--- a/quasi_codegen/Cargo.toml
+++ b/quasi_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quasi_codegen"
-version = "0.3.11"
+version = "0.3.12"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A quasi-quoting macro system"
@@ -12,5 +12,5 @@ with-syntex = ["syntex", "syntex_syntax", "aster/with-syntex"]
 
 [dependencies]
 aster = { version = "^0.9.2", default-features = false }
-syntex = { version = "^0.24.0", optional = true }
-syntex_syntax = { version = "^0.24.0", optional = true }
+syntex = { version = "^0.25.0", optional = true }
+syntex_syntax = { version = "^0.25.0", optional = true }

--- a/quasi_macros/Cargo.toml
+++ b/quasi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quasi_macros"
-version = "0.3.11"
+version = "0.3.12"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A quasi-quoting macro system"

--- a/quasi_tests/Cargo.toml
+++ b/quasi_tests/Cargo.toml
@@ -9,10 +9,10 @@ build = "build.rs"
 
 [build-dependencies]
 quasi_codegen = { version = "*", path = "../quasi_codegen" }
-syntex = { version = "^0.24.0" }
+syntex = { version = "^0.25.0" }
 
 [dev-dependencies]
 aster = { version = "^0.9.2", features = ["with-syntex"] }
 quasi = { version = "*", path = "../quasi", features = ["with-syntex"] }
-syntex = { version = "^0.24.0" }
-syntex_syntax = { version = "^0.24.0" }
+syntex = { version = "^0.25.0" }
+syntex_syntax = { version = "^0.25.0" }


### PR DESCRIPTION
Parse errors are emitted differently.
