### PR TITLE
Update for latest libsyntax changes

### DIFF
--- a/quasi/Cargo.toml
+++ b/quasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quasi"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A quasi-quoting macro system"

--- a/quasi/Cargo.toml
+++ b/quasi/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/erickt/rust-quasi"
 with-syntex = ["syntex_syntax"]
 
 [dependencies]
-syntex_syntax = { version = "^0.31.0", optional = true }
+syntex_syntax = { version = "^0.32.0", optional = true }

--- a/quasi/src/lib.rs
+++ b/quasi/src/lib.rs
@@ -79,7 +79,7 @@ impl<T: ToTokens> ToTokens for Option<T> {
 
 impl ToTokens for ast::Ident {
     fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> {
-        vec![ast::TokenTree::Token(DUMMY_SP, token::Ident(*self, token::Plain))]
+        vec![ast::TokenTree::Token(DUMMY_SP, token::Ident(*self))]
     }
 }
 

--- a/quasi_codegen/Cargo.toml
+++ b/quasi_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quasi_codegen"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A quasi-quoting macro system"

--- a/quasi_codegen/Cargo.toml
+++ b/quasi_codegen/Cargo.toml
@@ -11,6 +11,6 @@ default = ["with-syntex"]
 with-syntex = ["syntex", "syntex_syntax", "aster/with-syntex"]
 
 [dependencies]
-aster = { version = "^0.15.0", default-features = false }
-syntex = { version = "^0.31.0", optional = true }
-syntex_syntax = { version = "^0.31.0", optional = true }
+aster = { version = "^0.16.0", default-features = false }
+syntex = { version = "^0.32.0", optional = true }
+syntex_syntax = { version = "^0.32.0", optional = true }

--- a/quasi_codegen/src/lib.rs
+++ b/quasi_codegen/src/lib.rs
@@ -362,16 +362,10 @@ fn expr_mk_token(builder: &aster::AstBuilder, tok: &token::Token) -> P<ast::Expr
                 builder.expr().usize(n))
         }
 
-        token::Ident(ident, style) => {
-            let style = match style {
-                ModName => mk_token_path(builder, "ModName"),
-                Plain   => mk_token_path(builder, "Plain"),
-            };
-
+        token::Ident(ident) => {
             builder.expr().call()
                 .build(mk_token_path(builder, "Ident"))
                 .with_arg(mk_ident(builder, ident))
-                .with_arg(style)
                 .build()
         }
 
@@ -426,23 +420,11 @@ fn expr_mk_token(builder: &aster::AstBuilder, tok: &token::Token) -> P<ast::Expr
                 .build()
         }
 
-        token::MatchNt(name, kind, namep, kindp) => {
-            let namep = match namep {
-                ModName => mk_token_path(builder, "ModName"),
-                Plain => mk_token_path(builder, "Plain"),
-            };
-
-            let kindp = match kindp {
-                ModName => mk_token_path(builder, "ModName"),
-                Plain => mk_token_path(builder, "Plain"),
-            };
-
+        token::MatchNt(name, kind) => {
             builder.expr().call()
                 .build(mk_token_path(builder, "MatchNt"))
                 .arg().build(mk_ident(builder, name))
                 .arg().build(mk_ident(builder, kind))
-                .arg().build(namep)
-                .arg().build(kindp)
                 .build()
         }
 
@@ -463,7 +445,7 @@ fn statements_mk_tt(tt: &ast::TokenTree, matcher: bool) -> Result<QuoteStmts, ()
     let builder = aster::AstBuilder::new();
 
     match *tt {
-        ast::TokenTree::Token(sp, SubstNt(ident, _)) => {
+        ast::TokenTree::Token(sp, SubstNt(ident)) => {
             // tt.extend($ident.to_tokens(ext_cx).into_iter())
 
             let builder = builder.clone().span(sp);

--- a/quasi_macros/Cargo.toml
+++ b/quasi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quasi_macros"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A quasi-quoting macro system"
@@ -11,8 +11,8 @@ name = "quasi_macros"
 plugin = true
 
 [dependencies]
-quasi_codegen = { version = "^0.9.0", path = "../quasi_codegen", default-features = false }
+quasi_codegen = { version = "^0.10.0", path = "../quasi_codegen", default-features = false }
 
 [dev-dependencies]
 aster = "^0.16.0"
-quasi = { version = "^0.9.0", path = "../quasi" }
+quasi = { version = "^0.10.0", path = "../quasi" }

--- a/quasi_macros/Cargo.toml
+++ b/quasi_macros/Cargo.toml
@@ -14,5 +14,5 @@ plugin = true
 quasi_codegen = { version = "^0.9.0", path = "../quasi_codegen", default-features = false }
 
 [dev-dependencies]
-aster = "^0.15.0"
+aster = "^0.16.0"
 quasi = { version = "^0.9.0", path = "../quasi" }

--- a/quasi_tests/Cargo.toml
+++ b/quasi_tests/Cargo.toml
@@ -9,10 +9,10 @@ build = "build.rs"
 
 [build-dependencies]
 quasi_codegen = { path = "../quasi_codegen" }
-syntex = { version = "^0.31.0" }
+syntex = { version = "^0.32.0" }
 
 [dev-dependencies]
-aster = { version = "^0.15.0", features = ["with-syntex"] }
+aster = { version = "^0.16.0", features = ["with-syntex"] }
 quasi = { path = "../quasi", features = ["with-syntex"] }
-syntex = { version = "^0.31.0" }
-syntex_syntax = { version = "^0.31.0" }
+syntex = { version = "^0.32.0" }
+syntex_syntax = { version = "^0.32.0" }


### PR DESCRIPTION
Adapt to the changed interfaces, and bump the version number. (And of course also bump the dependencies on syntex and aster to enable the update.)
