### PR TITLE
Add quasi_codegen::expand and remove the public dependency on syntex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.0
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+* Replaced `quasi_codegen::register`'s public dependency on `syntex` with
+  `quasi_codegen::expand`.
+* Update to rustc 1.11.0-nightly (7d2f75a95 2016-06-09).
+
 ## 0.11.0
 
 BACKWARDS INCOMPATIBILITIES / NOTES:

--- a/quasi_codegen/src/lib.rs
+++ b/quasi_codegen/src/lib.rs
@@ -26,6 +26,12 @@ extern crate syntax;
 #[cfg(not(feature = "with-syntex"))]
 extern crate rustc_plugin;
 
+#[cfg(feature = "with-syntex")]
+use std::io;
+
+#[cfg(feature = "with-syntex")]
+use std::path::Path;
+
 use syntax::ast;
 use syntax::codemap::{Span, respan};
 use syntax::ext::base::ExtCtxt;
@@ -806,7 +812,17 @@ fn expand_parse_call(cx: &ExtCtxt,
 }
 
 #[cfg(feature = "with-syntex")]
-pub fn register(reg: &mut syntex::Registry) {
+pub fn expand<S, D>(src: S, dst: D) -> io::Result<()>
+    where S: AsRef<Path>,
+          D: AsRef<Path>,
+{
+    let mut registry = syntex::Registry::new();
+    register(&mut registry);
+    registry.expand("", src.as_ref(), dst.as_ref())
+}
+
+#[cfg(feature = "with-syntex")]
+fn register(reg: &mut syntex::Registry) {
     reg.add_macro("quote_tokens", expand_quote_tokens);
     reg.add_macro("quote_ty", expand_quote_ty);
     reg.add_macro("quote_expr", expand_quote_expr);

--- a/quasi_tests/build.rs
+++ b/quasi_tests/build.rs
@@ -1,4 +1,3 @@
-extern crate syntex;
 extern crate quasi_codegen;
 
 use std::env;
@@ -6,11 +5,9 @@ use std::path::Path;
 
 pub fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
-    let mut registry = syntex::Registry::new();
-    quasi_codegen::register(&mut registry);
 
     let src = Path::new("tests/test.rs.in");
     let dst = Path::new(&out_dir).join("test.rs");
 
-    registry.expand("", &src, &dst).unwrap();
+    quasi_codegen::expand(&src, &dst).unwrap();
 }


### PR DESCRIPTION
See https://github.com/serde-rs/serde/issues/358 for a more thorough explanation of the problem.

Blocked on #43 landing.
